### PR TITLE
Creates state and copy for cart

### DIFF
--- a/src/Products/Product.js
+++ b/src/Products/Product.js
@@ -9,7 +9,10 @@ function Product({ title, image, className }) {
         dispatch({
             type: 'ADD_TO_BASKET',
             item: {
+                //create id's per item
                 title: title,
+                image: '',
+                price: '',
             }
         })
         //logic for state change

--- a/src/Products/Product.js
+++ b/src/Products/Product.js
@@ -13,6 +13,7 @@ function Product({ title, image, className }) {
                 title: title,
                 image: '',
                 price: '',
+                rating: '',
             }
         })
         //logic for state change

--- a/src/Products/reducer.js
+++ b/src/Products/reducer.js
@@ -12,7 +12,8 @@ const reducer = (state, action) => {
         case "ADD_TO_BASKET":
             //logic to add to basket
             return {
-                ...state
+                ...state,
+                basket: [...state.basket, action.item]
             };
         case "REMOVE_FROM_BASKET":
             //logic to remove from basket

--- a/src/Products/reducer.js
+++ b/src/Products/reducer.js
@@ -7,14 +7,14 @@ export const initalState = {
     ],
 };
 
-function reducer(state, action) {
+const reducer = (state, action) => {
     switch (action.type) {
         case "ADD_TO_BASKET":
             //logic to add to basket
-            break;
+            return { state }
         case "REMOVE_FROM_BASKET":
             //logic to remove from basket
-            break;
+            return { state }
         default:
             return state;
     }

--- a/src/Products/reducer.js
+++ b/src/Products/reducer.js
@@ -11,10 +11,14 @@ const reducer = (state, action) => {
     switch (action.type) {
         case "ADD_TO_BASKET":
             //logic to add to basket
-            return { state }
+            return {
+                ...state
+            };
         case "REMOVE_FROM_BASKET":
             //logic to remove from basket
-            return { state }
+            return { 
+                state 
+            };
         default:
             return state;
     }


### PR DESCRIPTION
Creates basis for state that will be used to carry item information. 

For next steps, a new product section will be created to mimic the current version of Amazon, which does not have add to cart on landing. State holding item info will be used on the new product component.